### PR TITLE
Add publish workflow (Modrinth, CurseForge, GitHub Releases)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,122 @@
+name: Publish
+
+# Publishes the built jars to Modrinth, CurseForge and a GitHub Release.
+# Triggered by pushing a version tag, e.g.  git tag v2.3.0 && git push origin v2.3.0
+#
+# Required repository configuration (Settings -> Secrets and variables -> Actions):
+#   Secrets:
+#     MODRINTH_TOKEN        - Modrinth PAT with "Create versions" scope
+#     CURSEFORGE_TOKEN      - CurseForge API token (from https://legacy.curseforge.com/account/api-tokens)
+#   Variables:
+#     MODRINTH_PROJECT_ID   - Modrinth project id or slug (e.g. easyafk)
+#     CURSEFORGE_PROJECT_ID - CurseForge numeric project id (shown on the project page)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # needed to create the GitHub Release
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Read mod version
+        id: version
+        run: echo "version=$(grep '^version=' gradle.properties | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches gradle.properties version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PROP="${{ steps.version.outputs.version }}"
+          if [ "$TAG" != "$PROP" ]; then
+            echo "::error::Tag v$TAG does not match gradle.properties version $PROP"
+            exit 1
+          fi
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+
+      # ---- Fabric ----
+      - name: Publish Fabric
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          files: fabric/build/libs/!(*-@(dev|sources|javadoc)).jar
+          name: EasyAFK ${{ steps.version.outputs.version }} (Fabric)
+          version: ${{ steps.version.outputs.version }}
+          version-type: release
+          loaders: fabric
+          game-versions: '1.21.1'
+          dependencies: |
+            fabric-api(required)
+          java: '21'
+          retry-attempts: 3
+
+      # ---- NeoForge ----
+      - name: Publish NeoForge
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          files: neoforge/build/libs/!(*-@(dev|sources|javadoc)).jar
+          name: EasyAFK ${{ steps.version.outputs.version }} (NeoForge)
+          version: ${{ steps.version.outputs.version }}
+          version-type: release
+          loaders: neoforge
+          game-versions: '1.21.1'
+          java: '21'
+          retry-attempts: 3
+
+      # ---- Forge ----
+      - name: Publish Forge
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          files: forge/build/libs/!(*-@(dev|sources|javadoc)).jar
+          name: EasyAFK ${{ steps.version.outputs.version }} (Forge)
+          version: ${{ steps.version.outputs.version }}
+          version-type: release
+          loaders: forge
+          game-versions: '1.21.1'
+          java: '21'
+          retry-attempts: 3
+
+      # ---- GitHub Release (all three jars) ----
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: EasyAFK ${{ steps.version.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            fabric/build/libs/!(*-@(dev|sources|javadoc)).jar
+            neoforge/build/libs/!(*-@(dev|sources|javadoc)).jar
+            forge/build/libs/!(*-@(dev|sources|javadoc)).jar


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` — a GitHub Actions workflow that publishes new versions to **Modrinth**, **CurseForge**, and **GitHub Releases**.

Triggered by pushing a version tag (e.g. `git tag v2.3.0 && git push origin v2.3.0`).

## What it does

1. Sets up JDK 21 + Gradle and runs `./gradlew build` (builds all three loader jars).
2. Verifies the pushed tag matches `version=` in `gradle.properties` — fails fast on drift.
3. Publishes each loader jar separately (correct loader + game version per file) to Modrinth and CurseForge via `Kir-Antipov/mc-publish`. The Fabric upload declares `fabric-api` as a required dependency.
4. Creates a GitHub Release with all three jars attached and auto-generated notes.

## Required repo configuration (one time)

**Secrets:**
- `MODRINTH_TOKEN` — Modrinth PAT with "Create versions" scope
- `CURSEFORGE_TOKEN` — CurseForge API token

**Variables:**
- `MODRINTH_PROJECT_ID` — Modrinth slug or id (e.g. `easyafk`)
- `CURSEFORGE_PROJECT_ID` — numeric CurseForge project id

## Notes

- Game versions are hardcoded to `1.21.1` (matches this branch).
- Heads up: `gradle.properties` (`2.3.0`) and `version.txt` (`2.3.2`) currently disagree — reconcile before tagging, since the workflow builds/publishes from `gradle.properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)