### PR TITLE
Show AFK duration in the tab list (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The mod handles everything from **AFK detection**, **tab-list indicators**, **ti
 
 ## ✨ **Key Features include:**
 
-**Tablist Prefixes**
+**Tablist Prefixes** _(with optional live AFK duration, e.g. `[AFK] Steve (5m 12s)`)_
 
 ![Tablist Prefix](https://cdn.modrinth.com/data/cached_images/df40359b47bccad875c25b13f8c2ac1bc9fc95b4.png)
 

--- a/common/src/main/java/com/gemsi/easyafk/AFKDuration.java
+++ b/common/src/main/java/com/gemsi/easyafk/AFKDuration.java
@@ -1,0 +1,32 @@
+package com.gemsi.easyafk;
+
+/**
+ * Formats an AFK duration (in seconds) into a compact human-readable string,
+ * e.g. {@code 42s}, {@code 5m 12s}, {@code 1h 3m 7s}.
+ */
+public final class AFKDuration {
+
+    private AFKDuration() {
+    }
+
+    public static String format(long totalSeconds) {
+        if (totalSeconds < 0) {
+            totalSeconds = 0;
+        }
+
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+
+        StringBuilder builder = new StringBuilder();
+        if (hours > 0) {
+            builder.append(hours).append("h ");
+        }
+        if (hours > 0 || minutes > 0) {
+            builder.append(minutes).append("m ");
+        }
+        builder.append(seconds).append("s");
+
+        return builder.toString();
+    }
+}

--- a/common/src/main/java/com/gemsi/easyafk/Config.java
+++ b/common/src/main/java/com/gemsi/easyafk/Config.java
@@ -19,6 +19,7 @@ public class Config {
     // Message Settings
     public static boolean broadcastAFKMessages = true;
     public static boolean showAFKInTab = true;
+    public static boolean showAFKDurationInTab = true;
     public static boolean sendKickWarning = true;
     public static int kickWarningTime = 60;
 
@@ -46,6 +47,7 @@ public class Config {
     public static String msgCannotAfkRiding = "&cYou cannot go AFK while riding an entity!";
     public static String msgCannotAfkDangerous = "&cYou cannot go AFK in a dangerous location!";
     public static String afkPrefix = "&7[AFK] ";
+    public static String afkDurationFormat = "&7 ({time})";
     public static int colorAfkPlayerName = 0xFFFFFF;
 
     public static void load() {

--- a/fabric/src/main/java/com/gemsi/easyafk/AFKCommands.java
+++ b/fabric/src/main/java/com/gemsi/easyafk/AFKCommands.java
@@ -22,6 +22,9 @@ public class AFKCommands {
     // In-memory map to track AFK status
     public static final Map<UUID, Boolean> afkStatus = new HashMap<>();
 
+    // In-memory map tracking when each player entered AFK (epoch millis)
+    public static final Map<UUID, Long> afkSince = new HashMap<>();
+
     public static String canEnterAFK(ServerPlayer player) {
         UUID playerUUID = player.getUUID();
 
@@ -111,9 +114,22 @@ public class AFKCommands {
 
     public static void addPlayerAFK(UUID playerUUID) {
         afkStatus.put(playerUUID, true);
+        afkSince.put(playerUUID, System.currentTimeMillis());
     }
 
     public static void removeAFKStatus(UUID playerUUID) {
         afkStatus.remove(playerUUID);
+        afkSince.remove(playerUUID);
+    }
+
+    /**
+     * @return how many whole seconds the player has been AFK, or 0 if not AFK.
+     */
+    public static long getAFKDurationSeconds(UUID playerUUID) {
+        Long since = afkSince.get(playerUUID);
+        if (since == null) {
+            return 0;
+        }
+        return Math.max(0, (System.currentTimeMillis() - since) / 1000L);
     }
 }

--- a/fabric/src/main/java/com/gemsi/easyafk/AFKListener.java
+++ b/fabric/src/main/java/com/gemsi/easyafk/AFKListener.java
@@ -233,6 +233,11 @@ public class AFKListener {
                         int currentAFKTime = playerAFKTime.getOrDefault(playerUUID, 0) + 1;
                         playerAFKTime.put(playerUUID, currentAFKTime);
                         lastCheckTime.put(serverPlayer, currentTime);
+
+                        // Refresh the tab list once per second so the AFK duration stays current
+                        if (Config.showAFKInTab && Config.showAFKDurationInTab) {
+                            AFKPlayer.updateTabListName(serverPlayer);
+                        }
                     }
 
                     // Check for auto-kick

--- a/fabric/src/main/java/com/gemsi/easyafk/AFKPlayer.java
+++ b/fabric/src/main/java/com/gemsi/easyafk/AFKPlayer.java
@@ -2,7 +2,10 @@ package com.gemsi.easyafk;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.protocol.game.ClientboundClearTitlesPacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.network.protocol.game.ClientboundSetSubtitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
@@ -177,8 +180,8 @@ public class AFKPlayer {
         AFKListener.removeDamageCooldown(playerUUID);
         AFKListener.freezePlayerState(player);
 
-        // Fabric doesn't have refreshDisplayName/refreshTabListName
-        // The tab list updates automatically when player data changes
+        // Push the AFK-decorated tab list name (prefix + duration) to all clients
+        updateTabListName(player);
 
         // Display AFK title on player's screen
         displayAFKTitle(player);
@@ -212,8 +215,8 @@ public class AFKPlayer {
         AFKListener.clearKickWarning(playerUUID);
         playerLastPositions.remove(playerUUID);
 
-        // Fabric doesn't have refreshDisplayName/refreshTabListName
-        // The tab list updates automatically when player data changes
+        // Restore the plain tab list name now that the player is no longer AFK
+        updateTabListName(player);
 
         // Clear AFK title from player's screen
         clearAFKTitle(player);
@@ -232,5 +235,39 @@ public class AFKPlayer {
     public static void afkDisallow(ServerPlayer player) {
         Component coloredMessage = ColorParser.parseColors(Config.msgCannotDoWhileAfk);
         player.sendSystemMessage(coloredMessage);
+    }
+
+    /**
+     * Builds the tab list display name for an AFK player, e.g. "[AFK] Steve (5m 12s)".
+     * Used by {@code MixinServerPlayer} to override the vanilla tab list name on Fabric.
+     */
+    public static Component buildTabListName(ServerPlayer player) {
+        Component afkPrefix = ColorParser.parseColors(Config.afkPrefix);
+
+        Component playerNameComponent = Component.literal(player.getName().getString())
+                .setStyle(Style.EMPTY.withBold(false).withColor(TextColor.fromRgb(Config.colorAfkPlayerName)));
+
+        Component tablistName = afkPrefix.copy().append(playerNameComponent);
+
+        if (Config.showAFKDurationInTab) {
+            long seconds = AFKCommands.getAFKDurationSeconds(player.getUUID());
+            String durationText = Config.afkDurationFormat.replace("{time}", AFKDuration.format(seconds));
+            tablistName = tablistName.copy().append(ColorParser.parseColors(durationText));
+        }
+
+        return tablistName;
+    }
+
+    /**
+     * Broadcasts an updated tab list display name for the given player to all clients.
+     * Fabric has no {@code refreshTabListName()} helper, so we send the packet manually.
+     */
+    public static void updateTabListName(ServerPlayer player) {
+        if (player.getServer() == null) {
+            return;
+        }
+        player.getServer().getPlayerList().broadcastAll(
+                new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME, player)
+        );
     }
 }

--- a/fabric/src/main/java/com/gemsi/easyafk/mixin/MixinServerPlayer.java
+++ b/fabric/src/main/java/com/gemsi/easyafk/mixin/MixinServerPlayer.java
@@ -1,0 +1,27 @@
+package com.gemsi.easyafk.mixin;
+
+import com.gemsi.easyafk.AFKCommands;
+import com.gemsi.easyafk.AFKPlayer;
+import com.gemsi.easyafk.Config;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Fabric has no {@code TabListNameFormat} event like Forge/NeoForge, so we override
+ * the player's tab list display name directly to inject the AFK prefix and duration.
+ */
+@Mixin(ServerPlayer.class)
+public abstract class MixinServerPlayer {
+
+    @Inject(method = "getTabListDisplayName", at = @At("HEAD"), cancellable = true)
+    private void easyafk$afkTabListName(CallbackInfoReturnable<Component> cir) {
+        ServerPlayer self = (ServerPlayer) (Object) this;
+        if (Config.showAFKInTab && AFKCommands.getPlayerAFKStatus(self.getUUID())) {
+            cir.setReturnValue(AFKPlayer.buildTabListName(self));
+        }
+    }
+}

--- a/fabric/src/main/java/com/gemsi/easyafk/platform/FabricConfigService.java
+++ b/fabric/src/main/java/com/gemsi/easyafk/platform/FabricConfigService.java
@@ -50,6 +50,7 @@ public class FabricConfigService implements IConfigService {
             data.damageCooldown = Config.damageCooldown;
             data.broadcastAFKMessages = Config.broadcastAFKMessages;
             data.showAFKInTab = Config.showAFKInTab;
+            data.showAFKDurationInTab = Config.showAFKDurationInTab;
             data.sendKickWarning = Config.sendKickWarning;
             data.kickWarningTime = Config.kickWarningTime;
             data.preventFallDamage = Config.preventFallDamage;
@@ -71,6 +72,7 @@ public class FabricConfigService implements IConfigService {
             data.msgCannotAfkRiding = Config.msgCannotAfkRiding;
             data.msgCannotAfkDangerous = Config.msgCannotAfkDangerous;
             data.afkPrefix = Config.afkPrefix;
+            data.afkDurationFormat = Config.afkDurationFormat;
 
             GSON.toJson(data, writer);
         } catch (IOException e) {
@@ -86,6 +88,7 @@ public class FabricConfigService implements IConfigService {
         Config.damageCooldown = data.damageCooldown;
         Config.broadcastAFKMessages = data.broadcastAFKMessages;
         Config.showAFKInTab = data.showAFKInTab;
+        Config.showAFKDurationInTab = data.showAFKDurationInTab;
         Config.sendKickWarning = data.sendKickWarning;
         Config.kickWarningTime = data.kickWarningTime;
         Config.preventFallDamage = data.preventFallDamage;
@@ -107,6 +110,7 @@ public class FabricConfigService implements IConfigService {
         Config.msgCannotAfkRiding = keepOnNull(data.msgCannotAfkRiding, Config.msgCannotAfkRiding);
         Config.msgCannotAfkDangerous = keepOnNull(data.msgCannotAfkDangerous, Config.msgCannotAfkDangerous);
         Config.afkPrefix = keepOnNull(data.afkPrefix, Config.afkPrefix);
+        Config.afkDurationFormat = keepOnNull(data.afkDurationFormat, Config.afkDurationFormat);
         Config.colorAfkPlayerName = ColorParser.parseColor("#FFFFFF");
     }
 
@@ -122,6 +126,7 @@ public class FabricConfigService implements IConfigService {
         int damageCooldown = 15000;
         boolean broadcastAFKMessages = true;
         boolean showAFKInTab = true;
+        boolean showAFKDurationInTab = true;
         boolean sendKickWarning = true;
         int kickWarningTime = 60;
         boolean preventFallDamage = true;
@@ -143,5 +148,6 @@ public class FabricConfigService implements IConfigService {
         String msgCannotAfkRiding = "&cYou cannot go AFK while riding an entity!";
         String msgCannotAfkDangerous = "&cYou cannot go AFK in a dangerous location!";
         String afkPrefix = "&7[AFK] ";
+        String afkDurationFormat = "&7 ({time})";
     }
 }

--- a/fabric/src/main/resources/easyafk.fabric.mixins.json
+++ b/fabric/src/main/resources/easyafk.fabric.mixins.json
@@ -4,7 +4,9 @@
   "package": "com.gemsi.easyafk.mixin",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_21",
-  "mixins": [],
+  "mixins": [
+    "MixinServerPlayer"
+  ],
   "client": [
     "MixinTitleScreen"
   ],

--- a/forge/src/main/java/com/gemsi/easyafk/AFKCommands.java
+++ b/forge/src/main/java/com/gemsi/easyafk/AFKCommands.java
@@ -27,6 +27,9 @@ public class AFKCommands {
     // In-memory map to track AFK status
     public static final Map<UUID, Boolean> afkStatus = new HashMap<>();
 
+    // In-memory map tracking when each player entered AFK (epoch millis)
+    public static final Map<UUID, Long> afkSince = new HashMap<>();
+
     public static String canEnterAFK(ServerPlayer player) {
         UUID playerUUID = player.getUUID();
 
@@ -119,9 +122,22 @@ public class AFKCommands {
 
     public static void addPlayerAFK(UUID playerUUID) {
         afkStatus.put(playerUUID, true);
+        afkSince.put(playerUUID, System.currentTimeMillis());
     }
 
     public static void removeAFKStatus(UUID playerUUID) {
         afkStatus.remove(playerUUID);
+        afkSince.remove(playerUUID);
+    }
+
+    /**
+     * @return how many whole seconds the player has been AFK, or 0 if not AFK.
+     */
+    public static long getAFKDurationSeconds(UUID playerUUID) {
+        Long since = afkSince.get(playerUUID);
+        if (since == null) {
+            return 0;
+        }
+        return Math.max(0, (System.currentTimeMillis() - since) / 1000L);
     }
 }

--- a/forge/src/main/java/com/gemsi/easyafk/AFKListener.java
+++ b/forge/src/main/java/com/gemsi/easyafk/AFKListener.java
@@ -200,6 +200,11 @@ public class AFKListener {
                     int currentAFKTime = playerAFKTime.getOrDefault(playerUUID, 0) + 1;
                     playerAFKTime.put(playerUUID, currentAFKTime);
                     lastCheckTime.put(serverPlayer, currentTime);
+
+                    // Refresh the tab list once per second so the AFK duration stays current
+                    if (Config.showAFKInTab && Config.showAFKDurationInTab) {
+                        serverPlayer.refreshTabListName();
+                    }
                 }
 
                 // Check for auto-kick
@@ -478,6 +483,14 @@ public class AFKListener {
                     .setStyle(Style.EMPTY.withBold(false).withColor(TextColor.fromRgb(Config.colorAfkPlayerName)));
 
             Component tablistName = afkPrefix.copy().append(playerNameComponent);
+
+            // Append the live AFK duration, e.g. "[AFK] Steve (5m 12s)"
+            if (Config.showAFKDurationInTab) {
+                long seconds = AFKCommands.getAFKDurationSeconds(player.getUUID());
+                String durationText = Config.afkDurationFormat.replace("{time}", AFKDuration.format(seconds));
+                tablistName = tablistName.copy().append(ColorParser.parseColors(durationText));
+            }
+
             event.setDisplayName(tablistName);
         }
     }

--- a/forge/src/main/java/com/gemsi/easyafk/platform/ForgeConfigService.java
+++ b/forge/src/main/java/com/gemsi/easyafk/platform/ForgeConfigService.java
@@ -47,6 +47,10 @@ public class ForgeConfigService implements IConfigService {
             .comment("Whether to show [AFK] prefix in tab list (default: true)")
             .define("showAFKInTab", true);
 
+    private static final ForgeConfigSpec.BooleanValue SHOW_AFK_DURATION_IN_TAB = BUILDER
+            .comment("Whether to show how long a player has been AFK in the tab list (default: true)")
+            .define("showAFKDurationInTab", true);
+
     private static final ForgeConfigSpec.BooleanValue SEND_KICK_WARNING = BUILDER
             .comment("Whether to warn players before kicking them for AFK (default: true)")
             .define("sendKickWarning", true);
@@ -146,6 +150,10 @@ public class ForgeConfigService implements IConfigService {
             .comment("Prefix shown before player name in tab list when AFK")
             .define("messages.afkPrefix", "&7[AFK] ");
 
+    private static final ForgeConfigSpec.ConfigValue<String> AFK_DURATION_FORMAT = BUILDER
+            .comment("Format for the AFK duration in the tab list; {time} is replaced with the elapsed time (e.g. 5m 12s)")
+            .define("messages.afkDurationFormat", "&7 ({time})");
+
     public static final ForgeConfigSpec SPEC = BUILDER.build();
 
     @Override
@@ -163,6 +171,7 @@ public class ForgeConfigService implements IConfigService {
             Config.damageCooldown = DAMAGE_COOLDOWN.get();
             Config.broadcastAFKMessages = BROADCAST_AFK_MESSAGES.get();
             Config.showAFKInTab = SHOW_AFK_IN_TAB.get();
+            Config.showAFKDurationInTab = SHOW_AFK_DURATION_IN_TAB.get();
             Config.sendKickWarning = SEND_KICK_WARNING.get();
             Config.kickWarningTime = KICK_WARNING_TIME.get();
             Config.preventFallDamage = PREVENT_FALL_DAMAGE.get();
@@ -185,6 +194,7 @@ public class ForgeConfigService implements IConfigService {
             Config.msgCannotAfkRiding = MSG_CANNOT_AFK_RIDING.get();
             Config.msgCannotAfkDangerous = MSG_CANNOT_AFK_DANGEROUS.get();
             Config.afkPrefix = AFK_PREFIX.get();
+            Config.afkDurationFormat = AFK_DURATION_FORMAT.get();
 
             Config.colorAfkPlayerName = ColorParser.parseColor("#FFFFFF");
         }

--- a/neoforge/src/main/java/com/gemsi/easyafk/AFKCommands.java
+++ b/neoforge/src/main/java/com/gemsi/easyafk/AFKCommands.java
@@ -28,6 +28,9 @@ public class AFKCommands {
     // In-memory map to track AFK status
     public static final Map<UUID, Boolean> afkStatus = new HashMap<>();
 
+    // In-memory map tracking when each player entered AFK (epoch millis)
+    public static final Map<UUID, Long> afkSince = new HashMap<>();
+
     public AFKCommands() {
         NeoForge.EVENT_BUS.addListener(this::init);
     }
@@ -120,9 +123,22 @@ public class AFKCommands {
 
     public static void addPlayerAFK(UUID playerUUID) {
         afkStatus.put(playerUUID, true);
+        afkSince.put(playerUUID, System.currentTimeMillis());
     }
 
     public static void removeAFKStatus(UUID playerUUID) {
         afkStatus.remove(playerUUID);
+        afkSince.remove(playerUUID);
+    }
+
+    /**
+     * @return how many whole seconds the player has been AFK, or 0 if not AFK.
+     */
+    public static long getAFKDurationSeconds(UUID playerUUID) {
+        Long since = afkSince.get(playerUUID);
+        if (since == null) {
+            return 0;
+        }
+        return Math.max(0, (System.currentTimeMillis() - since) / 1000L);
     }
 }

--- a/neoforge/src/main/java/com/gemsi/easyafk/AFKListener.java
+++ b/neoforge/src/main/java/com/gemsi/easyafk/AFKListener.java
@@ -200,17 +200,17 @@ public class AFKListener {
                     int currentAFKTime = playerAFKTime.getOrDefault(playerUUID, 0) + 1;
                     playerAFKTime.put(playerUUID, currentAFKTime);
                     lastCheckTime.put(serverPlayer, currentTime);
+
+                    // Refresh the tab list once per second so the AFK duration stays current
+                    if (Config.showAFKInTab && Config.showAFKDurationInTab) {
+                        serverPlayer.refreshTabListName();
+                    }
                 }
 
                 // Check for auto-kick
                 if (Config.autoKickTimeout > 0) {
                     checkAutoKick(serverPlayer);
                 }
-            }
-
-            // Update tab list if needed
-            if (!AFKCommands.afkStatus.isEmpty()) {
-                serverPlayer.refreshTabListName();
             }
         }
     }
@@ -511,6 +511,14 @@ public class AFKListener {
                     .setStyle(Style.EMPTY.withBold(false).withColor(TextColor.fromRgb(Config.colorAfkPlayerName)));
 
             Component tablistName = afkPrefix.copy().append(playerNameComponent);
+
+            // Append the live AFK duration, e.g. "[AFK] Steve (5m 12s)"
+            if (Config.showAFKDurationInTab) {
+                long seconds = AFKCommands.getAFKDurationSeconds(player.getUUID());
+                String durationText = Config.afkDurationFormat.replace("{time}", AFKDuration.format(seconds));
+                tablistName = tablistName.copy().append(ColorParser.parseColors(durationText));
+            }
+
             event.setDisplayName(tablistName);
         }
     }

--- a/neoforge/src/main/java/com/gemsi/easyafk/platform/NeoForgeConfigService.java
+++ b/neoforge/src/main/java/com/gemsi/easyafk/platform/NeoForgeConfigService.java
@@ -47,6 +47,10 @@ public class NeoForgeConfigService implements IConfigService {
             .comment("Whether to show [AFK] prefix in tab list (default: true)")
             .define("showAFKInTab", true);
 
+    private static final ModConfigSpec.BooleanValue SHOW_AFK_DURATION_IN_TAB = BUILDER
+            .comment("Whether to show how long a player has been AFK in the tab list (default: true)")
+            .define("showAFKDurationInTab", true);
+
     private static final ModConfigSpec.BooleanValue SEND_KICK_WARNING = BUILDER
             .comment("Whether to warn players before kicking them for AFK (default: true)")
             .define("sendKickWarning", true);
@@ -146,6 +150,10 @@ public class NeoForgeConfigService implements IConfigService {
             .comment("Prefix shown before player name in tab list when AFK")
             .define("messages.afkPrefix", "&7[AFK] ");
 
+    private static final ModConfigSpec.ConfigValue<String> AFK_DURATION_FORMAT = BUILDER
+            .comment("Format for the AFK duration in the tab list; {time} is replaced with the elapsed time (e.g. 5m 12s)")
+            .define("messages.afkDurationFormat", "&7 ({time})");
+
     public static final ModConfigSpec SPEC = BUILDER.build();
 
     @Override
@@ -163,6 +171,7 @@ public class NeoForgeConfigService implements IConfigService {
             Config.damageCooldown = DAMAGE_COOLDOWN.get();
             Config.broadcastAFKMessages = BROADCAST_AFK_MESSAGES.get();
             Config.showAFKInTab = SHOW_AFK_IN_TAB.get();
+            Config.showAFKDurationInTab = SHOW_AFK_DURATION_IN_TAB.get();
             Config.sendKickWarning = SEND_KICK_WARNING.get();
             Config.kickWarningTime = KICK_WARNING_TIME.get();
             Config.preventFallDamage = PREVENT_FALL_DAMAGE.get();
@@ -185,6 +194,7 @@ public class NeoForgeConfigService implements IConfigService {
             Config.msgCannotAfkRiding = MSG_CANNOT_AFK_RIDING.get();
             Config.msgCannotAfkDangerous = MSG_CANNOT_AFK_DANGEROUS.get();
             Config.afkPrefix = AFK_PREFIX.get();
+            Config.afkDurationFormat = AFK_DURATION_FORMAT.get();
 
             Config.colorAfkPlayerName = ColorParser.parseColor("#FFFFFF");
         }


### PR DESCRIPTION
Closes #7.

Adds a live **AFK duration** to the tab list player name, e.g. `[AFK] Steve (5m 12s)`, updating once per second.

## What changed

**Common**
- New `AFKDuration` formatter (`42s`, `5m 12s`, `1h 3m 7s`).
- New config options `showAFKDurationInTab` (default `true`) and `afkDurationFormat` (default `&7 ({time})`, where `{time}` is replaced with the elapsed duration).

**Per-loader**
- `AFKCommands` now records when each player enters AFK (`afkSince`) and exposes `getAFKDurationSeconds()`.
- **Forge / NeoForge**: the existing `TabListNameFormat` handler now appends the duration, and the tab name is refreshed once per second while AFK. (Forge previously never refreshed the tab while AFK; NeoForge now refreshes per-second instead of every tick.)
- **Fabric**: previously had *no* tab decoration at all — the `showAFKInTab`/`afkPrefix` config existed but was unused. Added a `ServerPlayer` mixin overriding `getTabListDisplayName()` plus `ClientboundPlayerInfoUpdatePacket` resends, so the `[AFK]` prefix **and** the new duration now work on Fabric/Quilt too.

All three config backends (`ForgeConfigService`, `NeoForgeConfigService`, `FabricConfigService`) were updated with the two new options. Both new displays can be toggled off via config.

## Testing
- `./gradlew :common:compileJava :fabric:compileJava :forge:compileJava :neoforge:compileJava` — all modules compile cleanly (JDK 21).
- Not yet exercised in a live server; behaviour verified by code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)